### PR TITLE
Update to modifications in hpp-core

### DIFF
--- a/include/hpp/wholebody-step/fwd.hh
+++ b/include/hpp/wholebody-step/fwd.hh
@@ -45,7 +45,7 @@ namespace hpp {
     typedef constraints::SymbolicFunction<PointCom> PointComFunction;
     typedef constraints::SymbolicFunction<PointCom>::Ptr_t PointComFunctionPtr_t;
 
-    typedef core::Problem Problem;
+    typedef core::ProblemConstPtr_t ProblemConstPtr_t;
     typedef core::PathOptimizerPtr_t PathOptimizerPtr_t;
 
     typedef core::Path Path;

--- a/include/hpp/wholebody-step/small-steps.hh
+++ b/include/hpp/wholebody-step/small-steps.hh
@@ -56,7 +56,7 @@ namespace hpp {
       /// \param delegate path planner that will solve the initial path planning
       ///        problem for the sliding robot.
       /// \note the roadmap of this planner and of the delegate are the same.
-      static SmallStepsPtr_t create (const Problem& problem);
+      static SmallStepsPtr_t create (const ProblemConstPtr_t& problem);
       /// Call implementation of delegate path planner
       virtual PathVectorPtr_t optimize (const PathVectorPtr_t& path);
 
@@ -79,7 +79,7 @@ namespace hpp {
 
     protected:
       /// Constructor with roadmap
-      SmallSteps (const Problem& problem);
+      SmallSteps (const ProblemConstPtr_t& problem);
       /// Store weak pointer to itself
       void init (const SmallStepsWkPtr_t& weak);
     private:

--- a/src/small-steps.cc
+++ b/src/small-steps.cc
@@ -167,7 +167,7 @@ namespace hpp {
       pairs_ [t] = value;
     }
 
-    SmallStepsPtr_t SmallSteps::create (const Problem& problem)
+    SmallStepsPtr_t SmallSteps::create (const ProblemConstPtr_t& problem)
     {
       SmallSteps* ptr = new SmallSteps (problem);
       SmallStepsPtr_t shPtr (ptr);
@@ -175,7 +175,7 @@ namespace hpp {
       return shPtr;
     }
 
-    SmallSteps::SmallSteps (const Problem& problem) :
+    SmallSteps::SmallSteps (const ProblemConstPtr_t& problem) :
       core::PathOptimizer (problem), robot_ (), minStepLength_ (0.2),
       maxStepLength_ (0.2), defaultStepHeight_ (0.05),
       defaultDoubleSupportTime_ (0.1), defaultSingleSupportTime_ (0.6),
@@ -286,7 +286,7 @@ namespace hpp {
     PathVectorPtr_t SmallSteps::optimize (const PathVectorPtr_t& path)
     {
       // Check that robot is a humanoid robot
-      robot_ = HPP_DYNAMIC_PTR_CAST (HumanoidRobot, problem ().robot ());
+      robot_ = HPP_DYNAMIC_PTR_CAST (HumanoidRobot, problem()->robot ());
       if (!robot_) {
 	throw std::runtime_error ("Robot is not of type humanoid");
       }
@@ -358,7 +358,7 @@ namespace hpp {
         if (!valid) {
           lastProjFailed = opted;
         } else {
-          core::PathValidationPtr_t pv = problem().pathValidation ();
+          core::PathValidationPtr_t pv = problem()->pathValidation ();
           PathPtr_t unused;
           core::PathValidationReportPtr_t report;
           valid = pv->validate (opted, false, unused, report);


### PR DESCRIPTION
  - methods formerly taking a const reference to Problem as input now take
    a shared pointer to const Problem.

This PR requires https://github.com/humanoid-path-planner/hpp-core/pull/235 and https://github.com/humanoid-path-planner/hpp-corbaserver/pull/147.